### PR TITLE
Programmatically Add Arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ yarn add vue-chessground
 
 ## Documentation
 
-After installing, the component can be imported by name. It has 2 optional props:
+After installing, the component can be imported by name. It has 3 optional props:
 
 - `size: string` defaults to `512px`, determines height and width of the chessboard in pixels
 
 - `config: Partial<Config>` defaults to `{}`, determines various [configuration properties](https://github.com/ornicar/chessground/blob/master/src/config.ts#L7-L90) of Chessground
+
+- `arrows: DrawShape[]` defaults to `[]`, determines if any arrows should be added to the board
 
 Renders a simple `512 x 512` board, with pieces in their default position:
 

--- a/src/components/Chessboard/Chessboard.vue
+++ b/src/components/Chessboard/Chessboard.vue
@@ -9,10 +9,12 @@ import { onMounted, onUpdated, ref } from 'vue';
 import { Chessground as ChessgroundApi } from 'chessground';
 import type { Api } from 'chessground/api';
 import type { Config } from 'chessground/config';
+import type { DrawShape } from 'chessground/draw';
 
 interface Props {
   size?: string;
   config?: Partial<Config>;
+  arrows?: DrawShape[];
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -25,10 +27,18 @@ const cg = ref<Api | null>(null);
 
 onUpdated(() => {
   cg.value = ChessgroundApi(board.value!, props.config);
+
+  if (props.arrows) {
+    cg.value.setShapes(props.arrows);
+  }
 });
 
 onMounted(() => {
   cg.value = ChessgroundApi(board.value!, props.config);
+
+  if (props.arrows) {
+    cg.value.setShapes(props.arrows);
+  }
 });
 </script>
 


### PR DESCRIPTION
### Link To Issue:
N/A
### Description of Issue:
When adding the drawable field to the config object, arrows were not appearing on the board. The feature needed to address a need to add these arrows programmatically, rather than the user drawing them using the component.
### Solution:
Add a new property that takes the shapes to be drawn and pass those to the Chessground API.
### Notes:
